### PR TITLE
Avoid reduce and object spread

### DIFF
--- a/src/define.ts
+++ b/src/define.ts
@@ -80,10 +80,11 @@ function createGetPayloadFunction<T>(
           }
         } else if (rule.index) {
           hasAny = true;
-          result[key] = Object.keys(payload[key]).reduce((acc, childKey) => {
+          result[key] = {};
+          for (const childKey in payload[key]) {
             const childPayload = rule.index.getPayload(payload[key][childKey]);
-            return childPayload ? { ...acc, [childKey]: childPayload } : acc;
-          }, {});
+            if (childPayload) result[key][childKey] = childPayload;
+          }
         } else {
           hasAny = true;
           result[key] = payload[key];

--- a/src/functions/patch-each.ts
+++ b/src/functions/patch-each.ts
@@ -64,18 +64,24 @@ function patchEachFromArray<T>(
 ): Index<T> {
   if (!payload.length) return target;
 
-  return payload.reduce((acc, item) => {
+  const updates: Index<T> = {};
+
+  for (const item of payload) {
     const key = definition.getKey(item);
-    if (!key) return acc;
+    if (!key) continue;
 
     const existingItem = target[key];
-    if (!existingItem) return acc;
+    if (!existingItem) continue;
 
     const patchedItem = patch(existingItem, item, definition);
-    if (patchedItem === existingItem) return acc;
+    if (patchedItem === existingItem) continue;
 
-    return { ...(acc as any), [key]: patchedItem };
-  }, target);
+    updates[key] = patchedItem;
+  }
+
+  return Object.keys(updates).length
+    ? Object.assign({}, target, updates)
+    : target;
 }
 
 function patchEachFromIndex<T>(
@@ -85,21 +91,25 @@ function patchEachFromIndex<T>(
 ): Index<T> {
   if (!payload) return target;
 
-  const keys = Object.keys(payload);
-  if (!keys) return target;
+  const updates: Index<T> = {};
 
-  return keys.reduce((acc, key) => {
+  for (const key in payload) {
     const existingItem = target[key];
     if (!existingItem) {
       const newItem = definition.getPayload(payload[key]);
-      if (!newItem) return acc;
+      if (!newItem) continue;
 
-      return { ...(acc as any), [key]: newItem };
+      updates[key] = newItem;
+      continue;
     }
 
     const patchedItem = patch(existingItem, payload[key], definition);
-    if (patchedItem === existingItem) return acc;
+    if (patchedItem === existingItem) continue;
 
-    return { ...(acc as any), [key]: patchedItem };
-  }, target);
+    updates[key] = patchedItem;
+  }
+
+  return Object.keys(updates).length
+    ? Object.assign({}, target, updates)
+    : target;
 }

--- a/src/functions/patch.ts
+++ b/src/functions/patch.ts
@@ -66,7 +66,7 @@ function patchObject<T>(
   if (!patchValue) return target;
 
   let patched = false;
-  const result: T = { ...(target as any) };
+  const result: T = Object.assign({}, target);
 
   for (const key in patchValue) {
     const hasExistingValue = typeof result[key] !== 'undefined';
@@ -177,5 +177,5 @@ function patchIndex<T>(
 
   if (item === patchedItem) return target;
 
-  return { ...target, [key]: patchedItem };
+  return Object.assign({}, target, { [key]: patchedItem });
 }

--- a/src/functions/set-each.ts
+++ b/src/functions/set-each.ts
@@ -81,15 +81,21 @@ function setFromArray<T>(
   payload: T[],
   definition: Definition<T>,
 ): Index<T> {
-  return payload.reduce((acc, item) => {
+  const updates: Index<T> = {};
+
+  for (const item of payload) {
     const key = definition.getKey(item);
-    if (!key) return acc;
+    if (!key) continue;
 
     const validItem = definition.getPayload(item);
-    if (!validItem) return acc;
+    if (!validItem) continue;
 
-    return { ...acc, [key]: validItem };
-  }, target);
+    updates[key] = validItem;
+  }
+
+  return Object.keys(updates).length
+    ? Object.assign({}, target, updates)
+    : target;
 }
 
 function setFromIndex<T>(
@@ -98,16 +104,19 @@ function setFromIndex<T>(
   definition: Definition<T>,
 ): Index<T> {
   if (!payload) return target;
+  const updates: Index<T> = {};
 
-  const keys = Object.keys(payload);
-
-  return keys.reduce((acc, key) => {
+  for (const key in payload) {
     const validItem = definition.getPayload(payload[key]);
-    if (!validItem) return acc;
+    if (!validItem) continue;
 
     const keyFromDefinition = definition.getKey(validItem);
-    if (key !== keyFromDefinition) return acc;
+    if (key !== keyFromDefinition) continue;
 
-    return { ...acc, [key]: validItem };
-  }, target);
+    updates[key] = validItem;
+  }
+
+  return Object.keys(updates).length
+    ? Object.assign({}, target, updates)
+    : target;
 }

--- a/src/functions/unset-each.ts
+++ b/src/functions/unset-each.ts
@@ -41,5 +41,11 @@ function unsetFromIndex<T>(
 
   if (finalKeys.length === originalKeys.length) return target;
 
-  return finalKeys.reduce((acc, key) => ({ ...acc, [key]: target[key] }), {});
+  const result: Index<T> = {};
+
+  for (const key of finalKeys) {
+    result[key] = target[key];
+  }
+
+  return result;
 }

--- a/src/functions/unset.ts
+++ b/src/functions/unset.ts
@@ -36,7 +36,8 @@ function unsetFromObject<T>(
 function unsetFromIndex<T>(target: Index<T>, key: string): Index<T> {
   if (!target[key]) return target;
 
-  const { [key]: removed, ...rest } = target;
+  const result = Object.assign({}, target);
+  delete result[key];
 
-  return rest;
+  return result;
 }


### PR DESCRIPTION
This provides a performance improvement by not performing a full object copy on each iteration of the `.reduce` callback. Additionally, an `__assign` function is not built into the transpilation result.